### PR TITLE
Fix useless arg 01-create-efa-cluster.md

### DIFF
--- a/content/07-EFA/01-create-efa-cluster.md
+++ b/content/07-EFA/01-create-efa-cluster.md
@@ -65,7 +65,6 @@ placement_group = DYNAMIC
 placement = compute
 max_queue_size = 4
 initial_queue_size = 0
-maintain_initial_size = true
 disable_hyperthreading = true
 scheduler = slurm
 enable_efa = compute


### PR DESCRIPTION
With aws-parallelcluster 2.8.0, it is not allowed anymore to use both initial_queue_size=0 and maintain_initial_size=true. The second argument is useless in this case.

Signed-off-by: Alexandre Gobeaux gobeaa@amazon.com

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
