### PR TITLE
Install DCV GL Test Application on pcluster

### DIFF
--- a/content/06-nice-dcv/pcluster/04-connect-dcv.md
+++ b/content/06-nice-dcv/pcluster/04-connect-dcv.md
@@ -29,13 +29,48 @@ See example video below
   Your browser does not support the video tag.
 </video>
 
+Note: If you are using Firefox, you might have a warning because of the self-signed certificate. If this is the case, you can simply bypass this by clicking on **Advanced** and then **Accept the Risk and Continue**.
+
+
 Now that you can successfully connect to your NICE DCV session and open a terminal, you can next run a test application and visualize output.
 
-To run the DCV Test GL application, Go to **Applications** → **Other** → **DCV GL Test Application**
+In the current version of ParallelCluster, the DCV Test GL application that we want to run might not be available. Check if it is available by going to **Applications** → **Other** → **DCV GL Test Application**
 ![DCV Connect](/images/nice-dcv/Connect-DCV-StartGL.png)
 
-You should see this:
+If you have the application, run it. You should see this:
 ![DCV Connect](/images/nice-dcv/Connect-DCV-ViewGL.png)
+
+If the application is not available, go back to your Cloud9 environment and paste the following command in your terminal to connect to the master of your cluster:
+
+```bash
+pcluster ssh my-dcv-cluster -i ~/.ssh/lab-dcv-key
+```
+
+You can now paste the following commands:
+
+```bash
+cat > ./install_dcv_gltest.sh << EOF
+#!/bin/bash
+set -e # exit on error
+
+# install dcvgltest
+sudo rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY
+wget https://d1uj6qtbmh3dt5.cloudfront.net/2020.0/Servers/nice-dcv-2020.0-8428-el7.tgz
+tar -xvzf nice-dcv-2020.0-8428-el7.tgz
+cd nice-dcv-2020.0-8428-el7
+sudo yum install nice-dcv-gltest-2020.0.229-1.el7.x86_64.rpm
+EOF
+```
+
+This is a simple script to install the DCV Test GL application. If something does not work, please refer to the [DCV installation tutorial](https://docs.aws.amazon.com/dcv/latest/adminguide/setting-up-installing-linux-server.html#amazon-linux-2,-rhel-7.x,-and-centos-7.x) (steps 1 through 5 and then install the nice-dcv-gltest package).
+Paste this into your terminal to launch the installation script:
+
+```bash
+chmod +x ./install_dcv_gltest.sh
+./install_dcv_gltest.sh
+```
+
+You are now able to launch the DCV Test GL application as explained earlier.
 
 
 {{% notice tip %}}


### PR DESCRIPTION
DCV GL Test Application is not currently installed on pclusters, script is now provided to help customers install it easily. Asked Wanyi Chen to follow the updated tutorial, worked for her.
I also added a little note for Firefox users because it shows the self-signed certificate as a threat.

Signed-off-by: Alexandre Gobeaux gobeaa@amazon.com

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.