### PR TITLE
Added PrepAVWorkshop stack deletion in Batch workshop

### DIFF
--- a/content/05-AWS Batch/11-optional.md
+++ b/content/05-AWS Batch/11-optional.md
@@ -129,3 +129,10 @@ EOF
 bash remove-ce.sh
 ```
 6. Navigate to the [ECR](https://console.aws.amazon.com/ecr/repositories) Dashboard of the AWS Management Console and delete the repository you created earlier.
+
+7. Either delete the previously created PrepAVWorkshop stack using the CLI or the AWS Management Console:
+- CLI: use the following command in your Cloud9 Environment:
+```bash
+aws cloudformation delete-stack --stack-name PrepAVWorkshop
+```
+- Console: go to [CloudFormation](https://console.aws.amazon.com/cloudformation/), select the right region and the PrepAVWorkshop stack and click on *Delete*


### PR DESCRIPTION
The customer was not told to delete the stack before this patch (now it deletes the stack (and thus the S3 bucket that was created))

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
