### PR TITLE
change sanity check

### DIFF
--- a/content/04-Amazon FSx for Lustre/02-configure-pc-fsx.md
+++ b/content/04-Amazon FSx for Lustre/02-configure-pc-fsx.md
@@ -87,7 +87,7 @@ aws_region_name = ${REGION}
 [global]
 cluster_template = default
 update_check = false
-sanity_check = true
+sanity_check = false
 
 [cluster default]
 key_name = lab-4-your-key


### PR DESCRIPTION
If you follow the instructions exactly in a default Event Engine environment, you get an error trying to build the cluster...
Swapping the sanity check to false make the build work, though the error persists

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
