### PR TITLE
Fix pip version from 3.6 to 3

### DIFF
--- a/content/02-aws-getting-started/05-start-aws-cli.md
+++ b/content/02-aws-getting-started/05-start-aws-cli.md
@@ -30,7 +30,7 @@ Use the copy button in each of the following code samples to quickly copy the co
 
 Open a Terminal window and paste the following command to install the AWS CLI . Pip updates the version, if necessary. 
 ```bash
-pip-3.6 install awscli -U --user
+pip3 install awscli -U --user
 ```
 {{% notice info %}}
 If a warning message appears prompting you to upgrade PIP, ignore it.

--- a/content/03-hpc-aws-parallelcluster-workshop/02-install-PC.md
+++ b/content/03-hpc-aws-parallelcluster-workshop/02-install-PC.md
@@ -15,13 +15,13 @@ tags = ["tutorial", "install", "ParallelCluster"]
 First, let's upgrade the AWS CLI to get the latest version:
 
 ```bash
-pip-3.6 install awscli -U --user
+pip3 install awscli -U --user
 ```
 
 Install AWS ParallelCluster
 
 ```bash
-pip-3.6 install aws-parallelcluster -U --user
+pip3 install aws-parallelcluster -U --user
 ```
 
 Next, you configure AWS ParallelCluster.

--- a/content/04-Amazon FSx for Lustre/01-install-pc.md
+++ b/content/04-Amazon FSx for Lustre/01-install-pc.md
@@ -14,11 +14,11 @@ tags = ["tutorial", "install", "ParallelCluster"]
 Use the pip install command to install AWS ParallelCluster. Python and Python package management tool (PIP) are already installed in the Cloud9 environment.
 
 ```bash
-pip-3.6 install aws-parallelcluster -U --user
+pip3 install aws-parallelcluster -U --user
 ```
 
 Then upgrade the AWS CLI to get the latest version:
 
 ```bash
-pip-3.6 install awscli -U --user
+pip3 install awscli -U --user
 ```

--- a/content/07-EFA/01-create-efa-cluster.md
+++ b/content/07-EFA/01-create-efa-cluster.md
@@ -9,7 +9,7 @@ In this step, you create an HPC cluster configuration that includes parameters f
 
 {{% notice note %}}
 If you are not familiar with AWS ParallelCluster, we recommend that you first complete the [AWS ParallelCluster lab](../03-hpc-aws-parallelcluster-workshop.html) before proceeding.
-In particular, you need to follow the instructions to install AWS ParallelCluster: ```pip-3.6 install aws-parallelcluster -U --user && pip-3.6 install awscli -U --user```
+In particular, you need to follow the instructions to install AWS ParallelCluster: ```pip3 install aws-parallelcluster -U --user && pip3 install awscli -U --user```
 {{% /notice %}}
 
 #### Create a Cluster Configuration File for EFA


### PR DESCRIPTION
To be generic replacing pip-3.6 command by
pip3

*Issue #103 *

*Description of changes:*
Change `pip-3.6` command to `pip3` to be generic

Closes #103 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
