### PR TITLE
Fix environment variables to have 2 hyphens

### DIFF
--- a/content/05-AWS Batch/09-run-job.md
+++ b/content/05-AWS Batch/09-run-job.md
@@ -21,7 +21,7 @@ tags = ["tutorial", "install", "AWS", "batch", "Docker"]
 11. Expand the **Additional configuration** section.
 12. Under **Environment variables**, click **Add**.
 13. Set **Name** to: STRESS_ARGS
-14. Set **Value** to: --cpu 0 --cpu-method fft --timeout 1m --times
+14. Set **Value** to: `--cpu 0 --cpu-method fft --timeout 1m --times`
 ![AWS Batch](/images/aws-batch/run-job-4.png)
 15. Scroll to the bottom and click **Submit**.
 ![AWS Batch](/images/aws-batch/run-job-5.png)


### PR DESCRIPTION
Fix environment variables to have 2 hyphens in section Run a Batch Job using the Console when rendered in amplifyapp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
