### PR TITLE
Remove Unnecessary policy

### DIFF
--- a/static/template/cluster-config.yaml
+++ b/static/template/cluster-config.yaml
@@ -10,7 +10,6 @@ HeadNode:
   Iam:
     AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-      - Policy: arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole
   Dcv:
     Enabled: true
 Scheduling:


### PR DESCRIPTION
Signed-off-by: Sean Smith <seaam@amazon.com>'

Solves the error:

```
API: iam:AttachRolePolicy User: arn:aws:sts::833857487308:assumed-role/pcluster-manager-ParallelC-ParallelClusterUserRole-V5DO3R9W3T3Q/pcluster-manager-ParallelC-ParallelClusterFunction-Y7E54X3sGdo9 is not authorized to perform: iam:AttachRolePolicy on resource: role cluster-RoleHeadNode-DZ1IIF96ZZTL
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
