### PR TITLE
Updating external packages to match PC v 3.1.1

### DIFF
--- a/content/02-Cluster/05-external-packages.md
+++ b/content/02-Cluster/05-external-packages.md
@@ -4,6 +4,11 @@ weight: 25
 tags: ["tutorial", "pcluster-manager", "ParallelCluster", "Spack"]
 ---
 
+{{% notice note %}}
+The versions of these external packages changes with the version of parallel
+cluster. This `packages.yaml` is for parallel cluster version 3.1.1.
+{{% /notice %}}
+
 AWS ParallelCluster comes pre-installed with [Slurm](https://slurm.schedmd.com/), [libfabric](https://ofiwg.github.io/libfabric/), [PMIx](https://pmix.github.io/standard), [Intel MPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html), and [Open MPI](https://www.open-mpi.org/). To use these packages, we need to tell [spack where to find them](https://spack.readthedocs.io/en/latest/build_settings.html#external-packages).
 
 ```bash

--- a/content/02-Cluster/05-external-packages.md
+++ b/content/02-Cluster/05-external-packages.md
@@ -4,30 +4,36 @@ weight: 25
 tags: ["tutorial", "pcluster-manager", "ParallelCluster", "Spack"]
 ---
 
-AWS ParallelCluster comes pre-installed with Slurm, libfabric, Intel MPI and Open MPI. To use these packages, we need to tell [spack where to find them](https://spack.readthedocs.io/en/latest/build_settings.html#external-packages). 
+AWS ParallelCluster comes pre-installed with [Slurm](https://slurm.schedmd.com/), [libfabric](https://ofiwg.github.io/libfabric/), [PMIx](https://pmix.github.io/standard), [Intel MPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html), and [Open MPI](https://www.open-mpi.org/). To use these packages, we need to tell [spack where to find them](https://spack.readthedocs.io/en/latest/build_settings.html#external-packages).
 
 ```bash
 cat <<- EOF > $SPACK_ROOT/etc/spack/packages.yaml
 packages:
-    slurm:
-        externals:
-        - spec: slurm@20.11.7
-          prefix: /opt/slurm
-        buildable: False
-    libfabric:
-        externals:
-        - spec: libfabric@1.13.2
-          prefix: /opt/amazon/efa
-        buildable: False
-    openmpi:
-        externals:
-        - spec: openmpi@4.1.1
-          prefix: /opt/amazon/openmpi
-        buildable: False
     intel-mpi:
         externals:
         - spec: intel-mpi@2020.2.254
           prefix: /opt/intel/compilers_and_libraries_2020.2.254/linux/mpi/intel64
+        buildable: False
+    libfabric:
+        variants: fabrics=efa,tcp,udp,sockets,verbs,shm,mrail,rxd,rxm
+        externals:
+        - spec: libfabric@1.13.2 fabrics=efa,tcp,udp,sockets,verbs,shm,mrail,rxd,rxm
+          prefix: /opt/amazon/efa
+        buildable: False
+    openmpi:
+        variants: fabrics=auto +pmix +legacylaunchers schedulers=slurm
+        externals:
+        - spec: openmpi@4.1.1 fabrics=auto +pmix +legacylaunchers schedulers=slurm
+          prefix: /opt/amazon/openmpi
+    pmix:
+        externals:
+          - spec: pmix@3.2.3 ~pmi_backwards_compatibility
+            prefix: /opt/pmix
+    slurm:
+        variants: +pmix sysconfdir=/opt/slurm/etc
+        externals:
+        - spec: slurm@21.08.5 +pmix sysconfdir=/opt/slurm/etc
+          prefix: /opt/slurm
         buildable: False
 EOF
 ```


### PR DESCRIPTION
Updating the Spack `packages.yaml` file to represent Parallel Cluster version 3.1.1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
