### PR TITLE
Yaml here doc bugfixes

### DIFF
--- a/content/02-Cluster/05-external-packages.md
+++ b/content/02-Cluster/05-external-packages.md
@@ -7,7 +7,7 @@ tags: ["tutorial", "pcluster-manager", "ParallelCluster", "Spack"]
 AWS ParallelCluster comes pre-installed with Slurm, libfabric, Intel MPI and Open MPI. To use these packages, we need to tell [spack where to find them](https://spack.readthedocs.io/en/latest/build_settings.html#external-packages). 
 
 ```bash
-cat <<- EOF > $SPACK_ROOT/etc/spack/packages.yaml
+cat << EOF > $SPACK_ROOT/etc/spack/packages.yaml
 packages:
     slurm:
         externals:

--- a/content/03-WRF/05-custom-install-wrf.md
+++ b/content/03-WRF/05-custom-install-wrf.md
@@ -19,7 +19,7 @@ srun -N 1 --exclusive --pty /bin/bash -il
 2. Create the following spack environment file, specifying all the
    dependencies of WRF:
 ```bash
-cat <<- EOF > wrf_build.yaml
+cat << EOF > wrf_build.yaml
 # This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with


### PR DESCRIPTION
Removing the '-' in the creation of the here doc as this strips out leading tab characters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
