### PR TITLE
Hugo v0.92.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.hugo_build.lock
+public/*

--- a/amplify.yml
+++ b/amplify.yml
@@ -3,10 +3,10 @@ frontend:
   phases:
     build:
       commands:
-        - wget https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_0.58.3_Linux-64bit.tar.gz
-        - tar -xf hugo_0.58.3_Linux-64bit.tar.gz hugo
+        - wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.92.2/hugo_0.92.2_Linux-64bit.tar.gz
+        - tar -xf hugo.tar.gz hugo
         - mv hugo /usr/bin/hugo
-        - rm -rf hugo_0.58.3_Linux-64bit.tar.gz
+        - rm -rf hugo.tar.gz
         - hugo
   artifacts:
     baseDirectory: public

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -26,7 +26,7 @@
       <link href="{{(printf "css/theme-%s.css" .) | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     {{end}}
 
-    <script src="{{"js/jquery-3.5.1.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
+    <script src="{{"js/jquery-3.3.1.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 
     <style type="text/css">
       :root #header + #content > #left > #rlblock_left{


### PR DESCRIPTION
* Upgrade Hugo to `v0.92.2` which is the last version before they broke backwards compatibility
* Upgrade `hugo-theme-learn` to the latest version
* Fix issue with js version, this fixes the issues:
  * Scrolling side-bar
  * Mobile menu not working
  * Copy & paste code blocks

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
