### PR TITLE
Keypair in Getting Started

### DIFF
--- a/content/02-aws-getting-started/05-key-pair-create.md
+++ b/content/02-aws-getting-started/05-key-pair-create.md
@@ -16,6 +16,13 @@ aws ec2 create-key-pair --key-name lab-your-key --query KeyMaterial --output tex
 chmod 600 lab-your-key.pem
 ```
 
+Next add it to the `~/.bashrc` file, this allows us to reference it later:
+
+```bash
+echo "export AWS_KEYPAIR=lab-your-key" >> ~/.bashrc
+source ~/.bashrc
+```
+
 Optionally, use the following command to check if your key is registered:
 
 ```bash

--- a/content/04-Amazon FSx for Lustre/02-configure-pc-fsx.md
+++ b/content/04-Amazon FSx for Lustre/02-configure-pc-fsx.md
@@ -67,9 +67,6 @@ If you are using a different terminal than above, make sure that the Amazon S3 b
 Paste the following commands into your terminal to reuse the [**SSH key-pair**](/02-aws-getting-started/05-key-pair-create.html) created earlier:
 
 ```bash
-echo "export AWS_KEYPAIR=lab-your-key" >> ~/.bashrc
-source ~/.bashrc
-
 # create the cluster configuration
 IFACE=$(curl --silent http://169.254.169.254/latest/meta-data/network/interfaces/macs/)
 SUBNET_ID=$(curl --silent http://169.254.169.254/latest/meta-data/network/interfaces/macs/${IFACE}/subnet-id)
@@ -77,7 +74,8 @@ VPC_ID=$(curl --silent http://169.254.169.254/latest/meta-data/network/interface
 AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
 REGION=${AZ::-1}
 ```
-``` yaml
+
+```yaml
 cat > fsx-config.yaml << EOF
 Region: ${REGION}
 Image:

--- a/content/06-nice-dcv/pcluster/02-configure-pc-dcv.md
+++ b/content/06-nice-dcv/pcluster/02-configure-pc-dcv.md
@@ -32,12 +32,8 @@ For more details about the NICE DCV configuration options in AWS ParallelCLuster
 {{% /notice %}}
 
 We'll reuse the [**SSH key-pair**](/02-aws-getting-started/05-key-pair-create.html) created earlier.
-```bash
-echo "export AWS_KEYPAIR=lab-your-key" >> ~/.bashrc
-source ~/.bashrc
-```
 
-Then we'll create a config file (dcv-config.yaml). Paste the following commands in your terminal.
+Then we'll create a config file (`dcv-config.yaml`). Paste the following commands in your terminal.
 
 ```bash
 IFACE=$(curl --silent http://169.254.169.254/latest/meta-data/network/interfaces/macs/)
@@ -62,7 +58,7 @@ HeadNode:
   Networking:
     SubnetId: ${SUBNET_ID}
   Ssh:
-    KeyName: {AWS_KEYPAIR}
+    KeyName: ${AWS_KEYPAIR}
   Dcv:
     Emabled: true
 

--- a/content/07-EFA/01-create-efa-cluster.md
+++ b/content/07-EFA/01-create-efa-cluster.md
@@ -18,11 +18,6 @@ This section assumes that you are familiar with AWS ParallelCluster and the proc
 
 Let us reuse the [**SSH key-pair**](/02-aws-getting-started/05-key-pair-create.html) created earlier.
 
-```bash
-echo "export AWS_KEYPAIR=lab-your-key" >> ~/.bashrc
-source ~/.bashrc
-```
-
 The cluster configuration that you generate for EFA includes the following:
 
 - Set the compute nodes in a [Cluster Placement Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster) to maximize the bandwidth and reduce the latency between instances.

--- a/content/08-ml-on-parallelcluster/01-create-ml-cluster.md
+++ b/content/08-ml-on-parallelcluster/01-create-ml-cluster.md
@@ -19,11 +19,6 @@ This section assumes that you are familiar with AWS ParallelCluster and the proc
 
 Let us reuse the [**SSH key-pair**](/02-aws-getting-started/05-key-pair-create.html) created earlier.
 
-```bash
-echo "export AWS_KEYPAIR=lab-your-key" >> ~/.bashrc
-source ~/.bashrc
-```
-
 The cluster configuration that you generate for training large scale ML models includes constructs from EFA and FSx that you can explore in the previous sections of this workshop. The main additions to the cluster configuration script are:
 
 - Set the compute nodes as [p3dn.24xlarge instances](https://aws.amazon.com/ec2/instance-types/). The p3dn.24xlarge is one of the [EFA supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types) with multiple GPUs.
@@ -57,6 +52,7 @@ export VPC_ID=$(curl --silent http://169.254.169.254/latest/meta-data/network/in
 export AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
 export REGION=${AZ::-1}
 ```
+
 ```yaml
 cat > ml-config.yaml << EOF
 Region: ${REGION}


### PR DESCRIPTION
* Add `AWS_KEYPAIR` to ~/.bashrc in the getting started section. This prevents us from adding it multiple times.
* Consolidate all the yaml sections into a single section

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
