### PR TITLE
Update 06-install-intel-compilers.md

### DIFF
--- a/content/02-Cluster/06-install-intel-compilers.md
+++ b/content/02-Cluster/06-install-intel-compilers.md
@@ -9,7 +9,7 @@ tags: ["tutorial", "pcluster-manager", "ParallelCluster", "Spack"]
 Next we'll use Spack to install the [Intel Compilers (ICC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html), we'll use these to compile binaries such as WRF in the next few sections:
 
 ```bash
-spack install --no-cache intel-oneapi-compilers
+spack install --no-cache intel-oneapi-compilers@2022.0.2
 ```
 
 This will take about `~4 mins` to complete. Once it's complete we can see the installed package by running `spack find`:


### PR DESCRIPTION
Force Intel-one-api-compilers@2022.0.2, otherwise you will get 2022.1.0 which gives you the wrong compiler (2021.6.0 (at time of writing) rather than 2021.5.0) and the binary cache wont work.
I have left the MPI version because Spack isn't strict about that, but should probably also pin to `2021.5.0`.

It might be a good idea to clone Spack at a specific version / tag / hash - so as to pin the packages and their versions.

