### PR TITLE
Pinning Spack.

### DIFF
--- a/content/02-Cluster/04-install-spack.md
+++ b/content/02-Cluster/04-install-spack.md
@@ -14,7 +14,7 @@ First, on the head node - which we [connected to via SSM or DCV](02-connect-clus
 
 ```bash
 export SPACK_ROOT=/shared/spack
-git clone -c feature.manyFiles=true https://github.com/spack/spack $SPACK_ROOT
+git clone -b v0.18.0 -c feature.manyFiles=true https://github.com/spack/spack $SPACK_ROOT
 echo "export SPACK_ROOT=/shared/spack" >> $HOME/.bashrc
 echo "source \$SPACK_ROOT/share/spack/setup-env.sh" >> $HOME/.bashrc
 source $HOME/.bashrc

--- a/content/02-Cluster/05-external-packages.md
+++ b/content/02-Cluster/05-external-packages.md
@@ -26,9 +26,9 @@ packages:
           prefix: /opt/amazon/efa
         buildable: False
     openmpi:
-        variants: fabrics=auto +pmix +legacylaunchers schedulers=slurm
+        variants: fabrics=auto +legacylaunchers schedulers=slurm
         externals:
-        - spec: openmpi@4.1.1 fabrics=auto +pmix +legacylaunchers schedulers=slurm
+        - spec: openmpi@4.1.1 fabrics=auto +legacylaunchers schedulers=slurm
           prefix: /opt/amazon/openmpi
     pmix:
         externals:

--- a/content/02-Cluster/07-install-ncl.md
+++ b/content/02-Cluster/07-install-ncl.md
@@ -8,13 +8,12 @@ tags: ["tutorial", "pcluster-manager", "ParallelCluster", "NCL"]
 
 
 ```bash
-spack install --reuse ncl^hdf5@1.8.22
+spack install ncl^hdf5@1.8.22
 ```
 
 
 | **Spack Flag** | **Description** |
 | ----------- | ----------- |
-| `--reuse`   | [Reuse](https://spack.readthedocs.io/en/latest/basic_usage.html#reusing-installed-dependencies) installed dependencies. |
 | `ncl` | Install the NCL package. |
 | `^hdf5@1.8.22` | Pin the HDF5 dependency at version 1.8.22. |
 

--- a/content/03-WRF/01-spack-install-wrf.md
+++ b/content/03-WRF/01-spack-install-wrf.md
@@ -17,17 +17,16 @@ cat <<EOF > wrf-install.sbatch
 #SBATCH --exclusive
 
 echo "Installing WRF on \$SLURM_CPUS_ON_NODE cores."
-spack install --reuse -j \$SLURM_CPUS_ON_NODE wrf@4.3.3%intel build_type=dm+sm ^intel-oneapi-mpi+external-libfabric
+spack install -j \$SLURM_CPUS_ON_NODE wrf@4.3.3%intel build_type=dm+sm ^intel-oneapi-mpi+external-libfabric
 EOF
 ```
 
 * `-N 1` tells Slurm to allocate one instance
 * `--exclusive` tells slurm to use all the cores on that instance
-* `spack install --reuse -j $SLURM_CPUS_ON_NODE wrf%intel build_type=dm+sm ^intel-oneapi-mpi+external-libfabric` This tells Spack to install [WRF](https://spack.readthedocs.io/en/latest/package_list.html#wrf) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/wrf/package.py). It passes some build flags:
+* `spack install -j $SLURM_CPUS_ON_NODE wrf%intel build_type=dm+sm ^intel-oneapi-mpi+external-libfabric` This tells Spack to install [WRF](https://spack.readthedocs.io/en/latest/package_list.html#wrf) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/wrf/package.py). It passes some build flags:
 
 | **Spack Flag**   | **Description** |
 | ----------- | ----------- |
-| `--reuse`   | [Reuse](https://spack.readthedocs.io/en/latest/basic_usage.html#reusing-installed-dependencies) installed dependencies. |
 | `-j $SLURM_CPUS_ON_NODE`     | Compile with all the cores on the instance.   |
 | `@4.3.3`    | Specify version [4.3.3](https://github.com/wrf-model/WRF/releases/tag/v4.3.3) of WRF. |
 | `%intel`     | Specify the [Intel Compiler (icc)](https://spack.readthedocs.io/en/latest/package_list.html#intel-oneapi-compilers) we installed in [e. Install Intel Compilers](/02-cluster/06-install-intel-compilers.html#intel_compilers). |

--- a/content/03-WRF/05-custom-install-wrf.md
+++ b/content/03-WRF/05-custom-install-wrf.md
@@ -45,7 +45,7 @@ EOF
 ```bash
 spack env create wrf_build wrf_build.yaml
 spack env activate wrf_build
-spack install --reuse -j 16
+spack install -j 16
 ```
 4. Finally we're going to compile WRF using the dependencies we just installed:
 ```bash

--- a/content/04-MPAS/01-spack-install-mpas.md
+++ b/content/04-MPAS/01-spack-install-mpas.md
@@ -17,17 +17,16 @@ cat > mpas-install.sh <<EOF
 #SBATCH --exclusive
 
 echo "Installing MPAS on \$SLURM_CPUS_ON_NODE cores."
-spack install --reuse -j \$SLURM_CPUS_ON_NODE mpas-model%intel^intel-oneapi-mpi+external-libfabric^parallelio+pnetcdf
+spack install -j \$SLURM_CPUS_ON_NODE mpas-model%intel^intel-oneapi-mpi+external-libfabric^parallelio+pnetcdf
 EOF
 ```
 
 * `-N 1` tells Slurm to allocate one instance
 * `--exclusive` tells slurm to use all the cores on that instance
-* `spack install --reuse -j $SLURM_CPUS_ON_NODE mpas%intel^intel-oneapi-mpi+external-libfabric^parallelio+pnetcdf` This tells Spack to install [MPAS](https://spack.readthedocs.io/en/latest/package_list.html#mpas-model) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/mpas-model/package.py). It passes some build flags:
+* `spack install -j $SLURM_CPUS_ON_NODE mpas%intel^intel-oneapi-mpi+external-libfabric^parallelio+pnetcdf` This tells Spack to install [MPAS](https://spack.readthedocs.io/en/latest/package_list.html#mpas-model) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/mpas-model/package.py). It passes some build flags:
 
 | **Spack Flag**   | **Description** |
 | ----------- | ----------- |
-| `--reuse`   | [Reuse](https://spack.readthedocs.io/en/latest/basic_usage.html#reusing-installed-dependencies) installed dependencies. |
 | `-j $SLURM_CPUS_ON_NODE`     | Compile with all cores on the instance.   |
 | `%intel`     | Specify the [Intel Compiler (icc)](https://spack.readthedocs.io/en/latest/package_list.html#intel-oneapi-compilers) we installed in [e. Install Intel Compilers](/02-cluster/06-install-intel-compilers.html#intel_compilers). |
 | `^intel-onapi-mpi+external-libfabric` | Uses Intel MPI which we added in [e. Install Intel MPI](/02-cluster/06-install-intel-compilers.html#intel_mpi)

--- a/content/04-MPAS/02-supercell.md
+++ b/content/04-MPAS/02-supercell.md
@@ -25,7 +25,7 @@ will run MPAS on.
 1. Install [METIS](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) a graph partitioning program. This will take **~5 minutes**.
 
 ```bash
-spack install --reuse metis%intel
+spack install metis%intel
 ```
 
 2. Create a graph for the number of MPI ranks we will run MPAS on.

--- a/content/05-UFS/01-spack-install-ufs.md
+++ b/content/05-UFS/01-spack-install-ufs.md
@@ -17,17 +17,16 @@ cat > ufs-install.sh <<EOF
 #SBATCH --exclusive
 
 echo "Installing ufs on \$SLURM_CPUS_ON_NODE cores."
-spack install --reuse -j \$SLURM_CPUS_ON_NODE ufs-weather-model%intel^intel-oneapi-mpi+external-libfabric
+spack install -j \$SLURM_CPUS_ON_NODE ufs-weather-model%intel^intel-oneapi-mpi+external-libfabric
 EOF
 ```
 
 * `-N 1` tells Slurm to allocate one instance
 * `--exclusive` tells slurm to use all the cores on that instance
-* `spack install --reuse -j $SLURM_CPUS_ON_NODE ufs-weather-model%intel^intel-oneapi-mpi+external-libfabric` This tells Spack to install [UFS](https://spack.readthedocs.io/en/latest/package_list.html#ufs-weather-model) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/ufs-weather-model/package.py). It passes some build flags:
+* `spack install -j $SLURM_CPUS_ON_NODE ufs-weather-model%intel^intel-oneapi-mpi+external-libfabric` This tells Spack to install [UFS](https://spack.readthedocs.io/en/latest/package_list.html#ufs-weather-model) using the latest version in the [Spack recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/ufs-weather-model/package.py). It passes some build flags:
 
 | **Spack Flag**   | **Description** |
 | ----------- | ----------- |
-| `--reuse`   | [Reuse](https://spack.readthedocs.io/en/latest/basic_usage.html#reusing-installed-dependencies) installed dependencies. |
 | `-j $SLURM_CPUS_ON_NODE`     | Compile with all cores on the instance.   |
 | `%intel`     | Specify the [Intel Compiler (icc)](https://spack.readthedocs.io/en/latest/package_list.html#intel-oneapi-compilers) we installed in [e. Install Intel Compilers](/02-cluster/06-install-intel-compilers.html#intel_compilers). |
 | `^intel-oneapi-mpi+external-libfabric`  | Uses Intel MPI which we added in [e. Install Intel MPI](/02-cluster/06-install-intel-compilers.html#intel_mpi)


### PR DESCRIPTION
Pinning Spack to `v0.18.0`. Also removing the `--reuse` flag as
this is now the default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
