### PR TITLE
disable copy/paste for console-type code blocks

### DIFF
--- a/static/css/theme-mine.css
+++ b/static/css/theme-mine.css
@@ -279,3 +279,10 @@ div.notices.info p {
   .btn-default:active {
     background-image: none !important;
   }
+
+/*
+ * Turn off copy/paste for "console" code blocks
+ */
+code.language-console + .copy-to-clipboard {
+  display: none;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, there is no known way to disable the "copy/paste" icon in code blocks.  This is inconvenient for, e.g. console output that would be better formatted as a code block, but are not designed to be copied/pasted.  Having the copy/paste button in these blocks can lead to user confusion, and accidentally copy/pasting console output as commands.

Up to now, we have circumvented this issue by using screenshots instead of code blocks, but this approach is difficult to maintain.

This PR makes a small CSS change that will disable copy/paste blocks if the code type is *console*.  E.g.

```mmd
```console
output text here
will not have a copy button
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
