### PR TITLE
lab3: fix mangled path in curl

### DIFF
--- a/content/05-cicd-pipeline/06-updatebuild.md
+++ b/content/05-cicd-pipeline/06-updatebuild.md
@@ -22,7 +22,7 @@ The **inputs/** files contain a set of default inputs that we will use.  These f
 ```bash
 mkdir ~/environment/MyDemoRepo/inputs
 curl -o ~/environment/MyDemoRepo/inputs/md_0_1.tpr https://sc22-hpc-labs.s3.amazonaws.com/gromacs/inputs/md_0_1.tpr
-curl -o ~/environment/MyDemoRepo/inputs/inputs/topol.top https://sc22-hpc-labs.s3.amazonaws.com/gromacs/inputs/topol.top
+curl -o ~/environment/MyDemoRepo/inputs/topol.top https://sc22-hpc-labs.s3.amazonaws.com/gromacs/inputs/topol.top
 ```
 
 3. Add the **entrypoint.sh** script. This script will execute by default at the beginning of any container run to configure the container environment.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

curl command in lab3 got mangled in recent update.  This is a simple one-line fix for the curl output path in lab3 updatebuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
