### PR TITLE
Updated c6i template instance type formating

### DIFF
--- a/static/template/cluster-config-c6i.yml
+++ b/static/template/cluster-config-c6i.yml
@@ -21,8 +21,7 @@ Scheduling:
         - Name: c6i
           MinCount: 0
           MaxCount: 64
-          Instances:
-            - InstanceType: c6i.32xlarge
+          InstanceType: c6i.32xlarge
           Efa:
             Enabled: true
       Networking:


### PR DESCRIPTION
When I used the initial c6i template pcluster manager didn't recognize the c6i.32xlarge instance type and created a cluster with c5n instead. These changes fix that.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
