### PR TITLE
change the name of FSX_NAME

### DIFF
--- a/content/08-fsx-lustre/01-create-fsxl.md
+++ b/content/08-fsx-lustre/01-create-fsxl.md
@@ -17,7 +17,7 @@ cd ~/environment
 2. Define a FSx Lustre Filesystem Name
 
 ```bash
-export FSX_NAME="sc22lab2"
+export FSX_NAME="scalab2"
 ```
 
 3. Obtain the Compute Security Group ID of of your cluster. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Based on the meeting on Feb 21, change the FSX_NAME from sc22lab2 to scalab2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
