### PR TITLE
fix problems in the post-install and training scripts for the ML module

### DIFF
--- a/content/09-ml-on-parallelcluster/00-upload-training-data.md
+++ b/content/09-ml-on-parallelcluster/00-upload-training-data.md
@@ -41,6 +41,8 @@ The script also installs [Miniconda3](https://docs.conda.io/en/latest/miniconda.
 cat > post-install.sh << EOF
 #!/bin/bash
 
+export HOME=/home/ec2-user
+
 # start configuration of NCCL and EFA only if CUDA and EFA present
 CUDA_DIRECTORY=/usr/local/cuda
 EFA_DIRECTORY=/opt/amazon/efa

--- a/content/09-ml-on-parallelcluster/03-distributed-data-parallel.md
+++ b/content/09-ml-on-parallelcluster/03-distributed-data-parallel.md
@@ -25,7 +25,7 @@ SAVEDIR=/lustre/checkpoints
 WORLD_SIZE_JOB=\$SLURM_NTASKS
 RANK_NODE=\$SLURM_NODEID
 PROC_PER_NODE=8
-MASTER_ADDR_JOB=\$SLURM_SUBMIT_HOST
+MASTER_ADDR_JOB=(\`scontrol show hostnames \$SLURM_JOB_NODELIST | head -n 1\`)
 MASTER_PORT_JOB="12234"
 DDP_BACKEND=c10d
 
@@ -44,7 +44,7 @@ MAX_SENTENCES=8
 UPDATE_FREQ=1
 
 # calling fairseq-train
-python -m torch.distributed.launch \
+torchrun \
     --nproc_per_node=\$PROC_PER_NODE \
     --nnodes=\$WORLD_SIZE_JOB \
     --node_rank=\$RANK_NODE \
@@ -84,7 +84,7 @@ EOF
 chmod +x train.sh
 ```
 
-The script starts by setting up paths for the training data, output and checkpointing. All paths reference _/lustre_ and are visible by all compute nodes. Next, the script sets environment variables for the **PyTorch** _DistributedDataParalle API_ based on the **SLURM** environment. It also sets the required environment variables for [NCCL](https://developer.nvidia.com/nccl) to work with [AWS EFA](https://aws.amazon.com/hpc/efa/). The last section contains the command `python -m torch.distributed.launch`, which launches the training, based on the environment variables previously set. For more information on the _DistributedDataParalle API_, refer to the [documentation here](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
+The script starts by setting up paths for the training data, output and checkpointing. All paths reference _/lustre_ and are visible by all compute nodes. Next, the script sets environment variables for the **PyTorch** _DistributedDataParalle API_ based on the **SLURM** environment. It also sets the required environment variables for [NCCL](https://developer.nvidia.com/nccl) to work with [AWS EFA](https://aws.amazon.com/hpc/efa/). The last section contains the command `torchrun`, which launches the training, based on the environment variables previously set. For more information on the _DistributedDataParalle API_, refer to the [documentation here](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
 
 Create the **SLURM** batch script with the following commands:
 


### PR DESCRIPTION
*Description of changes:*

This PR will fix several problems that I encountered when following the instructions of the distributed ML module.
- Fix the missing "HOME" environmental variable in the post-install script that caused cluster creation failure. The error information I logged out during troubleshooting: `miniconda.sh: line 29: HOME: unbound variable`  
- Fix the `MASTER_ADDR_JOB` setting of the training script that caused the following error `[E socket.cpp:860] [c10d] The client socket has timed out after 900s while trying to connect to (ip-192-168-1-95, 12234)`. Currently, the value of this parameter is the host from where the Slurm job is submitted (usually the head node when using ParallelCluster); however, it should be set to one of the compute nodes (or "worker nodes" in general sense; see [here](https://pytorch.org/tutorials/intermediate/dist_tuto.html#:~:text=MASTER_ADDR%3A%20IP%20address%20of%20the%20machine%20that%20will%20host%20the%20process%20with%20rank%200.)).
- Fix a fairseq-train error in the training script caused by the `torch.distributed.launch` function by replacing it with `torchrun`. The error looks like `fairseq-train: error: unrecognized arguments: --local-rank=5`. It is known that (1) the `torch.distributed.launch` module is going to be deprecated in favor of `torchrun` and will be removed in the future (see [here](https://pytorch.org/docs/stable/distributed.html#backends:~:text=This%20module%20is%20going%20to%20be%20deprecated%20in%20favor%20of%20torchrun.)), (2) it has problem with handling the `--local-rank` argument (see [here](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launch.py#L182)).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
