### PR TITLE
Fix error while deploying S3BucketLogs

### DIFF
--- a/static/scripts/batch-lambda/CloudFormation/fsi-demo-s3.yaml
+++ b/static/scripts/batch-lambda/CloudFormation/fsi-demo-s3.yaml
@@ -197,6 +197,9 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       Tags:
         -
           Key: Description


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I was experimenting your workshop, and I found an issue building the infrastructure as described in the [Simulations with AWS Batch and Lambda](https://batch.hpcworkshops.com/05-aws-batch-and-lambda/setup/02-02-build-infra-index.html) section. Probably related to the change on the [Amazon S3 security changes](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/).
 
I saw the error: “Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting” while trying to create the S3BucketLogs. I solved it following the instruction on this re:Post: https://repost.aws/knowledge-center/cloudformation-objectownership-acl-error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
