### PR TITLE
linking fsx to s3 can now be done on linux as well as MacOS

### DIFF
--- a/content/06-fsx-for-lustre/04-link-s3-fsx.md
+++ b/content/06-fsx-for-lustre/04-link-s3-fsx.md
@@ -28,7 +28,8 @@ aws fsx create-data-repository-association \
     --file-system-id $FSX_ID \
     --file-system-path / \
     --data-repository-path s3://mybucket-${BUCKET_POSTFIX} \
-    --s3 AutoImportPolicy=\{"Events"=["NEW","CHANGED","DELETED"]\},AutoExportPolicy=\{"Events"=["NEW","CHANGED","DELETED"]\}
+    --s3 "AutoImportPolicy={Events=[NEW,CHANGED,DELETED]},AutoExportPolicy={Events=[NEW,CHANGED,DELETED]}" \
+    --batch-import-meta-data-on-create
 ```
 
 {{% notice info %}}


### PR DESCRIPTION
*Description of changes:*

Allowed the aws fsx create-data-repository-association command to also work on MacOS. Added --batch-import-meta-data-on-create so that the metadata of the s3 bucket is imported to the filesystem when the association is created.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
